### PR TITLE
feat(calendar): event CRUD met modaal, store en floating +

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "ignorePatterns": ["node_modules/", ".next/", "out/", "build/", "next-env.d.ts"]
+}

--- a/app/calendar/components/EventForm.tsx
+++ b/app/calendar/components/EventForm.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { format } from "date-fns";
+
+import { CalendarEvent, EventType } from "@/lib/types";
+
+type FormMode = "create" | "edit";
+
+type EventDraft = {
+  id?: string;
+  title: string;
+  type: EventType;
+  start: Date;
+  end: Date;
+  location?: string;
+  locked: boolean;
+  notes?: string;
+};
+
+interface EventFormProps {
+  open: boolean;
+  mode: FormMode;
+  initialEvent?: Partial<CalendarEvent>;
+  onClose: () => void;
+  onSubmit: (event: EventDraft) => void;
+  onDelete?: (id: string) => void;
+}
+
+const EVENT_TYPE_OPTIONS: { value: EventType; label: string }[] = [
+  { value: "lesson", label: "Les" },
+  { value: "study", label: "Studie" },
+  { value: "task", label: "Taak" },
+  { value: "exam", label: "Toets" },
+];
+
+export function EventForm({ open, mode, initialEvent, onClose, onSubmit, onDelete }: EventFormProps) {
+  const [draft, setDraft] = useState<EventDraft>(() => buildInitialDraft(initialEvent));
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDraft(buildInitialDraft(initialEvent));
+    setError(null);
+  }, [initialEvent, open]);
+
+  const title = mode === "create" ? "Nieuw event" : "Event bewerken";
+  const deleteEnabled = mode === "edit" && Boolean(draft.id) && typeof onDelete === "function";
+
+  const startValue = useMemo(() => formatLocalInput(draft.start), [draft.start]);
+  const endValue = useMemo(() => formatLocalInput(draft.end), [draft.end]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (draft.end <= draft.start) {
+      setError("Eindtijd moet later zijn dan starttijd.");
+      return;
+    }
+
+    onSubmit({ ...draft });
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8">
+      <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-soft">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
+            aria-label="Sluiten"
+          >
+            ×
+          </button>
+        </div>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="event-title">
+              Titel
+            </label>
+            <input
+              id="event-title"
+              value={draft.title}
+              onChange={(event) => setDraft((prev) => ({ ...prev, title: event.target.value }))}
+              className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+              placeholder="Bijv. Marketing college"
+              required
+            />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-slate-700" htmlFor="event-type">
+                Type
+              </label>
+              <select
+                id="event-type"
+                value={draft.type}
+                onChange={(event) => setDraft((prev) => ({ ...prev, type: event.target.value as EventType }))}
+                className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+              >
+                {EVENT_TYPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-slate-700" htmlFor="event-location">
+                Locatie
+              </label>
+              <input
+                id="event-location"
+                value={draft.location ?? ""}
+                onChange={(event) => setDraft((prev) => ({ ...prev, location: event.target.value }))}
+                className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+                placeholder="Bijv. Lokaal B2.10"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-slate-700" htmlFor="event-start">
+                Start
+              </label>
+              <input
+                id="event-start"
+                type="datetime-local"
+                value={startValue}
+                onChange={(event) => {
+                  const next = event.target.value ? new Date(event.target.value) : new Date();
+                  setDraft((prev) => ({ ...prev, start: next }));
+                }}
+                className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-slate-700" htmlFor="event-end">
+                Einde
+              </label>
+              <input
+                id="event-end"
+                type="datetime-local"
+                value={endValue}
+                onChange={(event) => {
+                  const next = event.target.value ? new Date(event.target.value) : new Date();
+                  setDraft((prev) => ({ ...prev, end: next }));
+                }}
+                className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="event-notes">
+              Notities
+            </label>
+            <textarea
+              id="event-notes"
+              value={draft.notes ?? ""}
+              onChange={(event) => setDraft((prev) => ({ ...prev, notes: event.target.value }))}
+              rows={3}
+              className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+              placeholder="Optioneel"
+            />
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-slate-700">
+            <input
+              type="checkbox"
+              checked={draft.locked}
+              onChange={(event) => setDraft((prev) => ({ ...prev, locked: event.target.checked }))}
+              className="h-4 w-4 rounded border-slate-300"
+            />
+            Vergrendeld (niet verplaatsen)
+          </label>
+
+          {error ? <p className="rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p> : null}
+
+          <div className="flex items-center justify-between pt-2">
+            {deleteEnabled ? (
+              <button
+                type="button"
+                onClick={() => draft.id && onDelete?.(draft.id)}
+                className="rounded-xl border border-red-200 px-3 py-2 text-sm font-medium text-red-600 transition hover:bg-red-50"
+              >
+                Verwijderen
+              </button>
+            ) : (
+              <span />
+            )}
+
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+              >
+                Annuleren
+              </button>
+              <button
+                type="submit"
+                className="rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-hover"
+              >
+                Opslaan
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function buildInitialDraft(event?: Partial<CalendarEvent>): EventDraft {
+  const start = event?.start ?? new Date();
+  const end = event?.end ?? new Date(start.getTime() + 60 * 60 * 1000);
+
+  return {
+    id: event?.id,
+    title: event?.title ?? "",
+    type: event?.type ?? "lesson",
+    start,
+    end,
+    location: event?.location,
+    locked: event?.locked ?? false,
+    notes: event?.notes,
+  };
+}
+
+function formatLocalInput(date: Date) {
+  try {
+    return format(date, "yyyy-MM-dd'T'HH:mm");
+  } catch {
+    return format(new Date(), "yyyy-MM-dd'T'HH:mm");
+  }
+}
+
+export type { EventDraft };

--- a/app/calendar/components/FabAdd.tsx
+++ b/app/calendar/components/FabAdd.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+interface FabAddProps {
+  onClick: () => void;
+}
+
+export function FabAdd({ onClick }: FabAddProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="fixed bottom-6 right-6 flex h-14 w-14 items-center justify-center rounded-full bg-brand text-white shadow-soft transition hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-brand/40"
+      aria-label="Nieuw event"
+    >
+      +
+    </button>
+  );
+}

--- a/app/calendar/components/RightDock.tsx
+++ b/app/calendar/components/RightDock.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+export function RightDock() {
+  return (
+    <aside className="rounded-2xl bg-white p-4 shadow-sm">
+      <h2 className="text-sm font-semibold text-slate-900">Komende uitbreidingen</h2>
+      <p className="mt-2 text-sm text-slate-600">
+        Hier verschijnen binnenkort snelle acties zoals CSV-import, AI-planner en conflictbeheer.
+      </p>
+    </aside>
+  );
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,10 +1,165 @@
-import { CalendarDashboard } from "@/components/calendar/CalendarDashboard";
-import { EventProvider } from "@/components/calendar/EventProvider";
+"use client";
+
+import "react-big-calendar/lib/css/react-big-calendar.css";
+
+import { useEffect, useMemo, useState } from "react";
+import { Calendar, SlotInfo, Views, dateFnsLocalizer } from "react-big-calendar";
+import { format, getDay, parse, startOfWeek } from "date-fns";
+import { nl } from "date-fns/locale";
+
+import { FabAdd } from "./components/FabAdd";
+import { EventForm, EventDraft } from "./components/EventForm";
+import { RightDock } from "./components/RightDock";
+import { useEventsStore } from "@/lib/useEventsStore";
+import { CalendarEvent } from "@/lib/types";
+
+const locales = {
+  nl,
+};
+
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek: () => startOfWeek(new Date(), { weekStartsOn: 1 }),
+  getDay,
+  locales,
+});
+
+type FormState =
+  | { open: false }
+  | {
+      open: true;
+      mode: "create" | "edit";
+      event?: CalendarEvent;
+      slotSuggestion?: Pick<CalendarEvent, "start" | "end">;
+    };
 
 export default function CalendarPage() {
+  const events = useEventsStore((store) => store.events);
+  const load = useEventsStore((store) => store.load);
+  const add = useEventsStore((store) => store.add);
+  const update = useEventsStore((store) => store.update);
+  const remove = useEventsStore((store) => store.remove);
+  const select = useEventsStore((store) => store.select);
+
+  const [formState, setFormState] = useState<FormState>({ open: false });
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const calendarEvents = useMemo(() => events.map((event) => ({ ...event })), [events]);
+
+  const eventPropGetter = (event: CalendarEvent) => {
+    const backgroundMap: Record<string, string> = {
+      lesson: "bg-lesson",
+      study: "bg-study",
+      task: "bg-task",
+      exam: "bg-exam",
+    };
+
+    const backgroundClass = backgroundMap[event.type] ?? "bg-slate-500";
+
+    return {
+      className: `${backgroundClass} !border-none !text-white rounded-md`,
+    };
+  };
+
+  const openCreateForm = (suggestion?: { start: Date; end: Date }) => {
+    select(null);
+    setFormState({ open: true, mode: "create", slotSuggestion: suggestion });
+  };
+
+  const openEditForm = (event: CalendarEvent) => {
+    select(event.id);
+    setFormState({ open: true, mode: "edit", event });
+  };
+
+  const handleFormClose = () => {
+    setFormState({ open: false });
+    select(null);
+  };
+
+  const handleFormSubmit = (draft: EventDraft) => {
+    if (formState.open && formState.mode === "edit" && formState.event) {
+      update({ ...formState.event, ...draft });
+    } else {
+      add({
+        title: draft.title,
+        type: draft.type,
+        start: draft.start,
+        end: draft.end,
+        location: draft.location,
+        locked: draft.locked,
+        notes: draft.notes,
+      });
+    }
+
+    handleFormClose();
+  };
+
+  const handleDelete = (id: string) => {
+    remove(id);
+    handleFormClose();
+  };
+
+  const handleSelectSlot = (slotInfo: SlotInfo) => {
+    if (slotInfo.action === "doubleClick") {
+      openCreateForm({ start: slotInfo.start, end: slotInfo.end });
+    }
+  };
+
+  const handleSelectEvent = (event: CalendarEvent) => {
+    openEditForm(event);
+  };
+
+  const handleAddClick = () => {
+    const start = new Date();
+    start.setMinutes(0, 0, 0);
+    const end = new Date(start.getTime() + 60 * 60 * 1000);
+    openCreateForm({ start, end });
+  };
+
+  const defaultDate = useMemo(() => (events.length ? events[0].start : new Date()), [events]);
+
   return (
-    <EventProvider>
-      <CalendarDashboard />
-    </EventProvider>
+    <div className="min-h-screen bg-slate-50">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-6 lg:flex-row">
+        <div className="flex-1 rounded-2xl bg-white p-4 shadow-sm">
+          <Calendar
+            culture="nl"
+            localizer={localizer}
+            events={calendarEvents}
+            startAccessor="start"
+            endAccessor="end"
+            views={[Views.WEEK, Views.DAY, Views.MONTH]}
+            defaultView={Views.WEEK}
+            defaultDate={defaultDate}
+            style={{ height: 640 }}
+            selectable
+            onSelectSlot={handleSelectSlot}
+            onSelectEvent={(event) => handleSelectEvent(event as CalendarEvent)}
+            eventPropGetter={(event) => eventPropGetter(event as CalendarEvent)}
+            onDoubleClickEvent={(event) => handleSelectEvent(event as CalendarEvent)}
+            popup
+          />
+        </div>
+
+        <div className="w-full shrink-0 lg:w-80">
+          <RightDock />
+        </div>
+      </div>
+
+      <EventForm
+        open={formState.open}
+        mode={formState.open ? formState.mode : "create"}
+        initialEvent={formState.open ? formState.event ?? formState.slotSuggestion : undefined}
+        onClose={handleFormClose}
+        onSubmit={handleFormSubmit}
+        onDelete={formState.open && formState.event ? handleDelete : undefined}
+      />
+
+      <FabAdd onClick={handleAddClick} />
+    </div>
   );
 }

--- a/components/calendar/CsvImportWizard.tsx
+++ b/components/calendar/CsvImportWizard.tsx
@@ -133,8 +133,8 @@ export function CsvImportWizard() {
       <footer className="mt-4 space-y-2 text-xs text-slate-500">
         <p>Voorbeeldregel:</p>
         <pre className="overflow-x-auto rounded-xl bg-slate-900 p-3 font-mono text-[11px] text-slate-100">
-title,start,end,type,location,rrule
-Marketing College,"2024-09-02T10:00:00","2024-09-02T12:00:00",lesson,Aula,"FREQ=WEEKLY;BYDAY=MO;COUNT=10"
+          {`title,start,end,type,location,rrule
+Marketing College,"2024-09-02T10:00:00","2024-09-02T12:00:00",lesson,Aula,"FREQ=WEEKLY;BYDAY=MO;COUNT=10"`}
         </pre>
       </footer>
     </section>

--- a/components/calendar/EventProvider.tsx
+++ b/components/calendar/EventProvider.tsx
@@ -143,23 +143,20 @@ export function EventProvider({ children }: { children: React.ReactNode }) {
 
   const clearWarnings = () => setWarnings([]);
 
-  const value = useMemo(
-    () => ({
-      events,
-      conflicts,
-      warnings,
-      lastPlan,
-      addEvent,
-      importEvents,
-      removeEvent,
-      toggleLock,
-      updateEventTime,
-      planStudyRequest,
-      resolveCurrentConflicts,
-      clearWarnings,
-    }),
-    [events, conflicts, warnings, lastPlan]
-  );
+  const value: EventContextValue = {
+    events,
+    conflicts,
+    warnings,
+    lastPlan,
+    addEvent,
+    importEvents,
+    removeEvent,
+    toggleLock,
+    updateEventTime,
+    planStudyRequest,
+    resolveCurrentConflicts,
+    clearWarnings,
+  };
 
   return <EventContext.Provider value={value}>{children}</EventContext.Provider>;
 }

--- a/components/calendar/WeekView.tsx
+++ b/components/calendar/WeekView.tsx
@@ -5,8 +5,11 @@ import "react-big-calendar/lib/css/react-big-calendar.css";
 import "react-big-calendar/lib/addons/dragAndDrop/styles.css";
 
 import { useMemo, useState } from "react";
+import type { ComponentType } from "react";
+import type { CalendarProps } from "react-big-calendar";
 import { Calendar, Views, dateFnsLocalizer } from "react-big-calendar";
 import withDragAndDrop from "react-big-calendar/lib/addons/dragAndDrop";
+import type { EventInteractionArgs } from "react-big-calendar/lib/addons/dragAndDrop";
 import { format, parse, startOfWeek, getDay } from "date-fns";
 import { nl } from "date-fns/locale";
 
@@ -26,7 +29,9 @@ type RBCEvt = {
   type?: "lesson" | "study" | "exam" | "task";
 };
 
-const DnDCalendar = withDragAndDrop<RBCEvt, object>(Calendar as any);
+const DnDCalendar = withDragAndDrop<RBCEvt, object>(
+  Calendar as unknown as ComponentType<CalendarProps<RBCEvt, object>>
+);
 
 export default function WeekView() {
   // demo events zodat je wat ziet
@@ -62,15 +67,11 @@ export default function WeekView() {
   };
 
   // simpele drag handlers (optioneel)
-  const onEventDrop = ({ event, start, end }: any) => {
-    setEvents((prev) =>
-      prev.map((e) => (e === event ? { ...e, start, end } : e))
-    );
+  const onEventDrop = ({ event, start, end }: EventInteractionArgs<RBCEvt>) => {
+    setEvents((prev) => prev.map((current) => (current === event ? { ...current, start: start as Date, end: end as Date } : current)));
   };
-  const onEventResize = ({ event, start, end }: any) => {
-    setEvents((prev) =>
-      prev.map((e) => (e === event ? { ...e, start, end } : e))
-    );
+  const onEventResize = ({ event, start, end }: EventInteractionArgs<RBCEvt>) => {
+    setEvents((prev) => prev.map((current) => (current === event ? { ...current, start: start as Date, end: end as Date } : current)));
   };
 
   return (

--- a/lib/eventUtils.ts
+++ b/lib/eventUtils.ts
@@ -1,0 +1,51 @@
+import { addHours, isValid } from "date-fns";
+
+import { CalendarEvent } from "./types";
+
+export function isOverlapping(a: CalendarEvent, b: CalendarEvent): boolean {
+  return a.start < b.end && b.start < a.end;
+}
+
+export function hasConflict(
+  events: CalendarEvent[],
+  candidate: CalendarEvent,
+  options: { ignoreId?: string } = {}
+): boolean {
+  const { ignoreId } = options;
+
+  return events.some((event) => {
+    if (event.id === candidate.id) {
+      return false;
+    }
+
+    if (ignoreId && event.id === ignoreId) {
+      return false;
+    }
+
+    return isOverlapping(event, candidate);
+  });
+}
+
+export function normalizeRange(startInput: Date, endInput: Date): { start: Date; end: Date } {
+  const start = cloneDate(startInput);
+  const end = cloneDate(endInput);
+
+  if (!isValid(start)) {
+    const now = new Date();
+    return { start: now, end: addHours(now, 1) };
+  }
+
+  if (!isValid(end)) {
+    return { start, end: addHours(start, 1) };
+  }
+
+  if (end <= start) {
+    return { start, end: addHours(start, 1) };
+  }
+
+  return { start, end };
+}
+
+function cloneDate(date: Date): Date {
+  return new Date(date.getTime());
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,12 @@
+export type EventType = "lesson" | "study" | "task" | "exam";
+
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  type: EventType;
+  location?: string;
+  locked?: boolean;
+  notes?: string;
+}

--- a/lib/useEventsStore.ts
+++ b/lib/useEventsStore.ts
@@ -1,0 +1,153 @@
+import { useSyncExternalStore } from "react";
+
+import { normalizeRange } from "./eventUtils";
+import { CalendarEvent } from "./types";
+
+const STORAGE_KEY = "agenda.events.v1";
+
+type EventsState = {
+  events: CalendarEvent[];
+  selectedId: string | null;
+  hasLoaded: boolean;
+};
+
+type EventInput = Omit<CalendarEvent, "id"> & { id?: string };
+
+type EventsActions = {
+  load: () => void;
+  add: (input: EventInput) => CalendarEvent;
+  update: (event: CalendarEvent) => void;
+  remove: (id: string) => void;
+  select: (id: string | null) => void;
+  clearAll: () => void;
+};
+
+type EventsStore = EventsState & EventsActions;
+
+const listeners = new Set<() => void>();
+
+const state: EventsState = {
+  events: [],
+  selectedId: null,
+  hasLoaded: false,
+};
+
+const actions: EventsActions = {
+  load() {
+    if (state.hasLoaded || typeof window === "undefined") {
+      state.hasLoaded = true;
+      return;
+    }
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+
+    if (!stored) {
+      state.hasLoaded = true;
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(stored) as Array<Omit<CalendarEvent, "start" | "end"> & { start: string; end: string }>;
+      state.events = parsed.map((item) => ({
+        ...item,
+        start: new Date(item.start),
+        end: new Date(item.end),
+      }));
+    } catch (error) {
+      console.warn("Kon events niet laden uit localStorage", error);
+      state.events = [];
+    }
+
+    state.hasLoaded = true;
+    emit();
+  },
+  add(input) {
+    const event = buildEvent(input);
+    state.events = [...state.events, event];
+    persist();
+    emit();
+    return event;
+  },
+  update(event) {
+    const { start, end } = normalizeRange(event.start, event.end);
+    state.events = state.events.map((item) => (item.id === event.id ? { ...event, start, end } : item));
+    persist();
+    emit();
+  },
+  remove(id) {
+    state.events = state.events.filter((event) => event.id !== id);
+    if (state.selectedId === id) {
+      state.selectedId = null;
+    }
+    persist();
+    emit();
+  },
+  select(id) {
+    state.selectedId = id;
+    emit();
+  },
+  clearAll() {
+    state.events = [];
+    state.selectedId = null;
+    persist();
+    emit();
+  },
+};
+
+function buildEvent(input: EventInput): CalendarEvent {
+  const id = input.id ?? generateId();
+  const { start, end } = normalizeRange(input.start, input.end);
+
+  return {
+    ...input,
+    id,
+    start,
+    end,
+  };
+}
+
+function persist() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const serialized = JSON.stringify(
+    state.events.map((event) => ({
+      ...event,
+      start: event.start.toISOString(),
+      end: event.end.toISOString(),
+    }))
+  );
+
+  window.localStorage.setItem(STORAGE_KEY, serialized);
+}
+
+function emit() {
+  listeners.forEach((listener) => listener());
+}
+
+function generateId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `event-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getStore(): EventsStore {
+  return {
+    ...state,
+    ...actions,
+  };
+}
+
+export function useEventsStore<T>(selector: (store: EventsStore) => T): T {
+  return useSyncExternalStore(subscribe, () => selector(getStore()), () => selector(getStore()));
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}


### PR DESCRIPTION
## Summary
- introduce strongly typed calendar events and utilities for overlap handling and date normalization
- add a localStorage-backed event store plus EventForm modal and floating action button to create, edit, and delete events from the week view
- tidy existing calendar helpers to keep linting green, including CSV preview escaping and drag-and-drop typing fixes

## Testing
- npm ci
- npm run lint
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e96af95574832b95d50b00f745b5e3